### PR TITLE
Allow showing individual collection bullets in the daily log

### DIFF
--- a/app/Http/Controllers/CollectionBulletController.php
+++ b/app/Http/Controllers/CollectionBulletController.php
@@ -26,7 +26,9 @@ class CollectionBulletController extends Controller
     {
         $this->authorize('update', $collection);
 
-        $bullet->update($request->only(['name', 'date', 'state']));
+        $bullet->update($request->only(
+            array_merge(['name', 'state'], $bullet->user_id === $request->user()->id ? ['date'] : [])
+        ));
 
         return redirect(route('c.show', $collection));
     }

--- a/app/Http/Controllers/CollectionBulletController.php
+++ b/app/Http/Controllers/CollectionBulletController.php
@@ -26,7 +26,7 @@ class CollectionBulletController extends Controller
     {
         $this->authorize('update', $collection);
 
-        $bullet->update($request->only(['name', 'state']));
+        $bullet->update($request->only(['name', 'date', 'state']));
 
         return redirect(route('c.show', $collection));
     }

--- a/app/Http/Controllers/CollectionBulletController.php
+++ b/app/Http/Controllers/CollectionBulletController.php
@@ -41,8 +41,10 @@ class CollectionBulletController extends Controller
         abort_if($bullet === null, 400, 'Invalid bullet');
         $this->authorize('update', $bullet);
 
+        if ($bullet->collection_id === null) {
+            $bullet->date = null;
+        }
         $bullet->collection_id = $collection->id;
-        $bullet->date = null;
         $bullet->save();
 
         return back();

--- a/app/Http/Controllers/DailyLogController.php
+++ b/app/Http/Controllers/DailyLogController.php
@@ -17,7 +17,6 @@ class DailyLogController extends Controller
             ->select('date')
             ->distinct()
             ->whereNotNull('date')
-            ->whereNull('collection_id')
             ->latest('date')
             ->take(6)
             ->pluck('date');
@@ -29,7 +28,6 @@ class DailyLogController extends Controller
                 ->oldest()
                 ->whereDate('date', '<=', $dates->first())
                 ->whereDate('date', '>=', $dates->last())
-                ->whereNull('collection_id')
                 ->get()
                 ->groupBy(fn ($bullet) => $bullet->date->format('Y-m-d'));
         }

--- a/resources/js/Components/Bullet.vue
+++ b/resources/js/Components/Bullet.vue
@@ -52,7 +52,7 @@
                                     <Icon name="small/x" class="w-6 h-6 md:w-5 md:h-5" />
                                 </button>
 
-                                <button v-if="bullet.collection_id === null && $date(bullet.date).isBefore($today())" class="h-10 w-10 md:h-8 md:w-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gray-100 dark:focus:bg-gray-800 focus:outline-none" @click="migrate(); menu = false" title="Migrate forward">
+                                <button v-if="enableMigrateForward && bullet.date && $date(bullet.date).isBefore($today())" class="h-10 w-10 md:h-8 md:w-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gray-100 dark:focus:bg-gray-800 focus:outline-none" @click="migrate(); menu = false" title="Migrate forward">
                                     <Icon name="small/chevron-up" class="h-6 w-6 md:h-5 md:w-5" />
                                 </button>
 
@@ -190,6 +190,7 @@ export default {
         'type',
         'props',
         'fade',
+        'enableMigrateForward',
     ],
 
     data() {

--- a/resources/js/Components/Bullet.vue
+++ b/resources/js/Components/Bullet.vue
@@ -134,10 +134,7 @@
                 </template>
             </div>
 
-            <div class="flex-1 ml-1 lg:flex">
-                <div v-if="$slots.tags" class="mt-1 -mb-1 md:mb-0 lg:hidden ml-2 md:ml-1 lg:flex-shrink-0">
-                    <slot name="tags" />
-                </div>
+            <div class="flex-1 ml-1 flex flex-col flex-col-reverse lg:flex-row">
                 <div class="lg:flex-1">
                     <textarea
                         ref="name"
@@ -163,7 +160,7 @@
                         spellcheck="false"
                     ></textarea>
                 </div>
-                <div v-if="$slots.tags" class="hidden lg:block -mt-1 mb-2 lg:mb-0 ml-2 md:ml-1 lg:mt-1 lg:flex-shrink-0">
+                <div v-if="$slots.tags" class="mt-1 -mb-1 md:mb-0 lg:mb-0 ml-2 md:ml-1 lg:flex-shrink-0">
                     <slot name="tags" />
                 </div>
             </div>

--- a/resources/js/Components/Bullet.vue
+++ b/resources/js/Components/Bullet.vue
@@ -62,10 +62,14 @@
 
                                 <button
                                     v-if="bullet.collection_id !== null"
-                                    class="h-10 w-10 md:h-8 md:w-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gray-100 dark:focus:bg-gray-800 focus:outline-none"
-                                    :class="bullet.date ? 'text-pink-600' : ''"
+                                    class="h-10 w-10 md:h-8 md:w-8 flex items-center justify-center"
+                                    :class="[
+                                        bullet.date && mine ? 'text-pink-600' : '',
+                                        mine ? 'hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gray-100 dark:focus:bg-gray-800 focus:outline-none' : 'text-gray-600 cursor-pointer',
+                                    ]"
+                                    :disabled="! mine"
                                     @click="toggleInDailyLog(); menu = false"
-                                    title="Show in daily log"
+                                    :title="mine ? 'Show in daily log' : 'Unable to show in daily log'"
                                 >
                                     <Icon name="medium/calendar" class="h-6 w-6 md:h-5 md:w-5" />
                                 </button>
@@ -204,7 +208,11 @@ export default {
             set(newValue) {
                 this.state = newValue ? 'complete' : 'incomplete'
             }
-        }
+        },
+
+        mine() {
+            return this.bullet.user_id === this.$page.props.user.id
+        },
     },
 
     watch: {

--- a/resources/js/Components/Bullet.vue
+++ b/resources/js/Components/Bullet.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <div class="py-1 md:py-2 flex">
-            <div class="relative flex-shrink-0" :class="$slots.tags ? 'pt-3 lg:pt-0' : ''">
+            <div class="relative flex-shrink-0" :class="$slots.tags ? 'mt-3 lg:mt-0' : ''">
                 <template v-if="type === 'bullet'">
                     <div class="border border-transparent" :class="fade">
                         <button

--- a/resources/js/Components/Bullet.vue
+++ b/resources/js/Components/Bullet.vue
@@ -60,6 +60,16 @@
                                     <Icon name="small/chevron-right" class="h-6 w-6 md:h-5 md:w-5" />
                                 </button>
 
+                                <button
+                                    v-if="bullet.collection_id !== null"
+                                    class="h-10 w-10 md:h-8 md:w-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gray-100 dark:focus:bg-gray-800 focus:outline-none"
+                                    :class="bullet.date ? 'text-pink-600' : ''"
+                                    @click="toggleInDailyLog(); menu = false"
+                                    title="Show in daily log"
+                                >
+                                    <Icon name="medium/calendar" class="h-6 w-6 md:h-5 md:w-5" />
+                                </button>
+
                                 <button class="h-10 w-10 md:h-8 md:w-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gray-100 dark:focus:bg-gray-800 focus:outline-none" @click="destroy(); menu = false" title="Delete">
                                     <Icon name="small/trash" class="h-6 w-6 md:w-5 md:h-5" />
                                 </button>
@@ -120,30 +130,38 @@
                 </template>
             </div>
 
-            <div class="flex-1 mx-1">
-                <textarea
-                    ref="name"
-                    v-model="name"
-                    :disabled="processing"
-                    class="w-full p-2 md:p-1 overflow-hidden bg-transparent border-none disabled:opacity-75 focus:ring-0"
-                    :class="[
-                        fade,
-                        complete ? 'text-gray-500 dark:text-gray-500' : 'text-gray-900 dark:text-gray-100'
-                    ]"
-                    style="resize: none;"
-                    rows="1"
-                    maxlength="255"
-                    @keydown.enter="
-                        if (! $event.shiftKey && $event.target.value.length) {
-                            $event.preventDefault()
-                            save()
-                        }
-                    "
-                    @keydown.up="up"
-                    @keydown.down="down"
-                    @blur="$event.target.value.length > 0 ? save() : destroy()"
-                    spellcheck="false"
-                ></textarea>
+            <div class="flex-1 ml-1 lg:flex">
+                <div class="lg:flex-1">
+                    <textarea
+                        ref="name"
+                        v-model="name"
+                        :disabled="processing"
+                        class="w-full p-2 md:p-1 overflow-hidden bg-transparent border-none disabled:opacity-75 focus:ring-0"
+                        :class="[
+                            fade,
+                            complete ? 'text-gray-500 dark:text-gray-500' : 'text-gray-900 dark:text-gray-100'
+                        ]"
+                        style="resize: none;"
+                        rows="1"
+                        maxlength="255"
+                        @keydown.enter="
+                            if (! $event.shiftKey && $event.target.value.length) {
+                                $event.preventDefault()
+                                save()
+                            }
+                        "
+                        @keydown.up="up"
+                        @keydown.down="down"
+                        @blur="$event.target.value.length > 0 ? save() : destroy()"
+                        spellcheck="false"
+                    ></textarea>
+                </div>
+                <div v-if="$slots.tags" class="-mt-1 mb-2 lg:mb-0 ml-2 md:ml-1 lg:mt-1 lg:flex-shrink-0">
+                    <slot name="tags" />
+                </div>
+            </div>
+            <div class="flex-shrink-0">
+                <slot name="status" />
             </div>
         </div>
 
@@ -217,6 +235,18 @@ export default {
 
             this.processing = false;
             this.dirty = false;
+        },
+
+        async toggleInDailyLog() {
+            if (this.bullet.collection_id === null) {
+                return;
+            }
+
+            this.processing = true;
+
+            await this.$listeners.input({ id: this.bullet.id, date: this.bullet.date ? null : this.$today().format('YYYY-MM-DD') })
+
+            this.processing = false;
         },
 
         async migrate() {

--- a/resources/js/Components/Bullet.vue
+++ b/resources/js/Components/Bullet.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <div class="py-1 md:py-2 flex">
-            <div class="relative flex-shrink-0">
+            <div class="relative flex-shrink-0" :class="$slots.tags ? 'pt-3 lg:pt-0' : ''">
                 <template v-if="type === 'bullet'">
                     <div class="border border-transparent" :class="fade">
                         <button
@@ -135,6 +135,9 @@
             </div>
 
             <div class="flex-1 ml-1 lg:flex">
+                <div v-if="$slots.tags" class="mt-1 -mb-1 md:mb-0 lg:hidden ml-2 md:ml-1 lg:flex-shrink-0">
+                    <slot name="tags" />
+                </div>
                 <div class="lg:flex-1">
                     <textarea
                         ref="name"
@@ -160,7 +163,7 @@
                         spellcheck="false"
                     ></textarea>
                 </div>
-                <div v-if="$slots.tags" class="-mt-1 mb-2 lg:mb-0 ml-2 md:ml-1 lg:mt-1 lg:flex-shrink-0">
+                <div v-if="$slots.tags" class="hidden lg:block -mt-1 mb-2 lg:mb-0 ml-2 md:ml-1 lg:mt-1 lg:flex-shrink-0">
                     <slot name="tags" />
                 </div>
             </div>

--- a/resources/js/Components/Bullet.vue
+++ b/resources/js/Components/Bullet.vue
@@ -69,7 +69,7 @@
                                     ]"
                                     :disabled="! mine"
                                     @click="toggleInDailyLog(); menu = false"
-                                    :title="mine ? 'Show in daily log' : 'Unable to show in daily log'"
+                                    :title="mine ? (bullet.date ? 'Hide in daily log' : 'Show in daily log') : 'Unable to show in daily log'"
                                 >
                                     <Icon name="medium/calendar" class="h-6 w-6 md:h-5 md:w-5" />
                                 </button>

--- a/resources/js/Pages/Collection.vue
+++ b/resources/js/Pages/Collection.vue
@@ -29,7 +29,7 @@
                     spellcheck="false"
                 />
 
-                <div class="-mr-2 flex gap-2 text-gray-400">
+                <div class="flex gap-2 text-gray-400">
                     <button
                         type="button"
                         @click="hideDone = ! hideDone"

--- a/resources/js/Pages/Collection.vue
+++ b/resources/js/Pages/Collection.vue
@@ -164,7 +164,18 @@
                 @delete="deleteBullet"
                 @migrateTo="migrateBulletTo"
                 @migrateToDailyLog="migrateBulletToDailyLog"
-            />
+            >
+                <template #status>
+                    <inertia-link
+                        v-if="bullet.date"
+                        :href="route('daily-log.index')"
+                        title="Appears in daily log"
+                        class="inline-block ml-2 md:-mt-1 -mb-1 p-2 rounded-md text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-900 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 transition duration-150 ease-in-out"
+                    >
+                        <Icon name="medium/calendar" class="h-6 w-6 md:h-5 md:w-5" />
+                    </inertia-link>
+                </template>
+            </bullet>
         </div>
 
         <new-bullet @input="storeBullet" />

--- a/resources/js/Pages/Collection.vue
+++ b/resources/js/Pages/Collection.vue
@@ -170,7 +170,10 @@
                         v-if="bullet.date && bullet.user_id === $page.props.user.id"
                         :href="route('daily-log.index')"
                         title="Appears in daily log"
-                        class="inline-block ml-2 md:-mt-1 -mb-1 p-2 rounded-md text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-900 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 transition duration-150 ease-in-out"
+                        class="inline-block ml-2 md:-mt-1 -mb-1 p-2 rounded-md text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 transition duration-150 ease-in-out"
+                        :class="[
+                            bullet.complete ? 'opacity-50' : ''
+                        ]"
                     >
                         <Icon name="medium/calendar" class="h-6 w-6 md:h-5 md:w-5" />
                     </inertia-link>

--- a/resources/js/Pages/Collection.vue
+++ b/resources/js/Pages/Collection.vue
@@ -167,7 +167,7 @@
             >
                 <template #status>
                     <inertia-link
-                        v-if="bullet.date"
+                        v-if="bullet.date && bullet.user_id === $page.props.user.id"
                         :href="route('daily-log.index')"
                         title="Appears in daily log"
                         class="inline-block ml-2 md:-mt-1 -mb-1 p-2 rounded-md text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-900 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 transition duration-150 ease-in-out"

--- a/resources/js/Pages/Collection.vue
+++ b/resources/js/Pages/Collection.vue
@@ -25,11 +25,11 @@
                 <input
                     type="text"
                     v-model.lazy="name"
-                    class="flex-1 px-0 py-3 font-bold border-none bg-transparent text-gray-700 dark:text-gray-200 focus:ring-0"
+                    class="w-full flex-1 px-0 py-3 font-bold border-none bg-transparent text-gray-700 dark:text-gray-200 focus:ring-0"
                     spellcheck="false"
                 />
 
-                <div class="flex gap-2 text-gray-400">
+                <div class="flex flex-shrink-0 gap-2 text-gray-400">
                     <button
                         type="button"
                         @click="hideDone = ! hideDone"

--- a/resources/js/Pages/DailyLog.vue
+++ b/resources/js/Pages/DailyLog.vue
@@ -42,7 +42,10 @@
                         v-if="bullet.collection_id"
                         :href="route('c.show', $page.props.collections.find(collection => collection.id === bullet.collection_id).hashid)"
                         title="Appears in collection"
-                        class="inline-block px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-gray-500 dark:text-gray-300 text-xs hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none focus:bg-gray-200 dark:focus:bg-gray-600 transition duration-150 ease-in-out"
+                        class="inline-block lg:px-2 lg:py-1 lg:bg-gray-100 lg:dark:bg-gray-700 rounded text-gray-500 dark:text-gray-500 lg:dark:text-gray-300 text-xs lg:hover:bg-gray-200 lg:dark:hover:bg-gray-600 focus:outline-none lg:focus:bg-gray-200 lg:dark:focus:bg-gray-600 transition duration-150 ease-in-out"
+                        :class="[
+                            bullet.complete ? 'opacity-50' : ''
+                        ]"
                     >
                         {{ $page.props.collections.find(collection => collection.id === bullet.collection_id).name }}
                     </inertia-link>

--- a/resources/js/Pages/DailyLog.vue
+++ b/resources/js/Pages/DailyLog.vue
@@ -32,6 +32,7 @@
                     'opacity-30': i === 5,
                 }"
                 type="bullet"
+                :enable-migrate-forward="true"
                 @input="updateBullet"
                 @migrate="migrateBullet"
                 @migrateTo="migrateBulletTo"

--- a/resources/js/Pages/DailyLog.vue
+++ b/resources/js/Pages/DailyLog.vue
@@ -36,7 +36,18 @@
                 @migrate="migrateBullet"
                 @migrateTo="migrateBulletTo"
                 @delete="deleteBullet"
-            />
+            >
+                <template #tags>
+                    <inertia-link
+                        v-if="bullet.collection_id"
+                        :href="route('c.show', $page.props.collections.find(collection => collection.id === bullet.collection_id).hashid)"
+                        title="Appears in collection"
+                        class="inline-block px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-gray-500 dark:text-gray-300 text-xs hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none focus:bg-gray-200 dark:focus:bg-gray-600 transition duration-150 ease-in-out"
+                    >
+                        {{ $page.props.collections.find(collection => collection.id === bullet.collection_id).name }}
+                    </inertia-link>
+                </template>
+            </bullet>
 
             <new-bullet v-if="i == 0" @input="storeBullet" />
         </div>


### PR DESCRIPTION
I like to keep collections for each of the projects I'm working on so that I can log ideas, tasks, and bugs. When an item is ready to action, I like to pull it into the daily log.

Currently I use the "migrate to collection" feature to move the bullet into the daily log. This has a few potential downsides:

* The bullet no longer appears in the collection
* Often the bullets are written in the context of a project-specific collection, so they lack that context in the daily log. I often find myself manually adding a project prefix or rewording the bullet.

This PR adds a new "Show in daily log" feature which you'll find in the bullet menu of any bullet that belongs to a collection.

![image](https://user-images.githubusercontent.com/4977161/124382424-b6ba3480-dd0a-11eb-9df6-df47916d14f5.png)

When enabled, the bullet will appear both in the daily log and in its collection.

In the collection, bullets shared with the daily log are indicated with an icon.

![image](https://user-images.githubusercontent.com/4977161/124382702-1533e280-dd0c-11eb-8afb-988d09529614.png)

In the daily log, bullets belonging to collections have a label indicating which collection they are from, which provides valuable context and an overview of how your daily log is categorised.

![image](https://user-images.githubusercontent.com/4977161/124382535-495ad380-dd0b-11eb-8f55-1eb53bddd643.png)

Note this is only available for bullets that you create yourself. You won't be able to use this on bullets created by others in a shared collection.

Suggest reviewing with [hide whitespace changes](https://github.com/jessarcher/rocketlog/pull/4/files?w=1) enabled.