### PR TITLE
Refresh on update (polling)

### DIFF
--- a/app/Http/Controllers/CollectionBulletController.php
+++ b/app/Http/Controllers/CollectionBulletController.php
@@ -19,6 +19,8 @@ class CollectionBulletController extends Controller
             'user_id' => $request->user()->id,
         ]);
 
+        $collection->clearCache();
+
         return redirect(route('c.show', $collection));
     }
 
@@ -26,9 +28,15 @@ class CollectionBulletController extends Controller
     {
         $this->authorize('update', $collection);
 
+        if ($request->has('date') || $bullet->date) {
+            $request->user()->clearDailyLogCache();
+        }
+
         $bullet->update($request->only(
             array_merge(['name', 'state'], $bullet->user_id === $request->user()->id ? ['date'] : [])
         ));
+
+        $collection->clearCache();
 
         return redirect(route('c.show', $collection));
     }
@@ -41,11 +49,17 @@ class CollectionBulletController extends Controller
         abort_if($bullet === null, 400, 'Invalid bullet');
         $this->authorize('update', $bullet);
 
+        if ($bullet->date) {
+            $request->user()->clearDailyLogCache();
+        }
+
         if ($bullet->collection_id === null) {
             $bullet->date = null;
         }
         $bullet->collection_id = $collection->id;
         $bullet->save();
+
+        $collection->clearCache();
 
         return back();
     }
@@ -54,7 +68,12 @@ class CollectionBulletController extends Controller
     {
         $this->authorize('update', $collection);
 
+        if ($bullet->date) {
+            $request->user()->clearDailyLogCache();
+        }
+
         $bullet->delete();
+        $collection->clearCache();
 
         return redirect(route('c.show', $collection));
     }

--- a/app/Http/Controllers/CollectionBulletDoneController.php
+++ b/app/Http/Controllers/CollectionBulletDoneController.php
@@ -7,11 +7,19 @@ use Illuminate\Http\Request;
 
 class CollectionBulletDoneController extends Controller
 {
-    public function destroy(Collection $collection)
+    public function destroy(Request $request, Collection $collection)
     {
         $this->authorize('update', $collection);
 
-        $collection->bullets()->whereState('complete')->delete();
+        $bullets = $collection->bullets()->whereState('complete')->get();
+
+        if ($bullets->contains(fn ($bullet) => $bullet->date)) {
+            $request->user()->clearDailyLogCache();
+        }
+
+        $bullets->each->delete();
+
+        $collection->clearCache();
 
         return redirect(route('c.show', $collection));
     }

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -24,9 +24,7 @@ class CollectionController extends Controller
     {
         $this->authorize($collection);
 
-        return Inertia::render('Collection', [
-            'collection' => $collection->load('bullets', 'users'),
-        ]);
+        return Inertia::render('Collection', ['collection' => $collection]);
     }
 
     public function update(Collection $collection, Request $request)
@@ -41,14 +39,19 @@ class CollectionController extends Controller
 
         $collection->update($request->only(['name', 'type', 'hide_done']));
 
+        $collection->clearCache();
+
         return redirect(route('c.show', $collection));
     }
 
-    public function destroy(Collection $collection)
+    public function destroy(Request $request, Collection $collection)
     {
         $this->authorize($collection);
 
+        $collection->clearCache();
         $collection->delete();
+
+        $request->user()->clearDailyLogCache();
 
         return redirect(route('daily-log.index'));
     }

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -20,11 +20,15 @@ class CollectionController extends Controller
         return redirect(route('c.show', $collection));
     }
 
-    public function show(Collection $collection)
+    public function show(Request $request, Collection $collection)
     {
         $this->authorize($collection);
 
-        return Inertia::render('Collection', ['collection' => $collection]);
+        if ($request->query('hashonly')) {
+            return $collection->hash;
+        }
+
+        return Inertia::render('Collection', ['collection' => $collection, 'hash' => $collection->hash]);
     }
 
     public function update(Collection $collection, Request $request)

--- a/app/Http/Controllers/CollectionUserController.php
+++ b/app/Http/Controllers/CollectionUserController.php
@@ -11,6 +11,7 @@ class CollectionUserController extends Controller
     public function store(InviteUserToCollectionRequest $request, Collection $collection)
     {
         $collection->users()->attach($request->invitedUser);
+        $collection->clearCache();
 
         return redirect(route('c.show', $collection));
     }
@@ -20,6 +21,7 @@ class CollectionUserController extends Controller
         $this->authorize('update', $collection);
 
         $collection->users()->detach($user);
+        $collection->clearCache();
 
         return redirect(route('c.show', $collection));
     }

--- a/app/Http/Controllers/DailyLogController.php
+++ b/app/Http/Controllers/DailyLogController.php
@@ -102,9 +102,10 @@ class DailyLogController extends Controller
             $bullet->collection->clearCache();
         }
 
-        $bullet->collection_id = null;
-        $bullet->date = $request->input('date');
-        $bullet->save();
+        $bullet->update([
+            'collection_id' => null,
+            'date' => $request->input('date'),
+        ]);
 
         $request->user()->clearDailyLogCache();
 

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -15,6 +15,8 @@ class Collection extends Model
     use HasHashid;
     use HashidRouting;
 
+    public string $hash;
+
     protected $guarded = [];
 
     protected $casts = [
@@ -60,7 +62,10 @@ class Collection extends Model
         return Cache::remember(
             "collections.{$value}",
             now()->addDay(),
-            fn () => self::with('bullets', 'users')->findByHashidOrFail($value)
+            fn () => tap(
+                self::with('bullets', 'users')->findByHashidOrFail($value),
+                fn ($collection) => $collection->hash = md5($collection->toJson())
+            )
         );
     }
 

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Mtvs\EloquentHashids\HasHashid;
 use Mtvs\EloquentHashids\HashidRouting;
@@ -52,5 +53,19 @@ class Collection extends Model
             'state' => 'incomplete',
             'user_id' => $this->user_id,
         ], $attributes));
+    }
+
+    public function resolveRouteBinding($value, $field = null)
+    {
+        return Cache::remember(
+            "collections.{$value}",
+            now()->addDay(),
+            fn () => self::with('bullets', 'users')->findByHashidOrFail($value)
+        );
+    }
+
+    public function clearCache()
+    {
+        Cache::forget("collections.{$this->hashid()}");
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Cache;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
@@ -80,5 +81,10 @@ class User extends Authenticatable implements MustVerifyEmail
     public function sharedCollections()
     {
         return $this->belongsToMany(Collection::class)->orderBy('name');
+    }
+
+    public function clearDailyLogCache()
+    {
+        Cache::forget("users.{$this->id}.daily-log");
     }
 }

--- a/public/icons/medium/refresh.svg
+++ b/public/icons/medium/refresh.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="transform: scale(-1, 1)">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+</svg>

--- a/public/icons/small/refresh.svg
+++ b/public/icons/small/refresh.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" style="transform: scale(-1, 1)">
+    <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd" />
+</svg>

--- a/resources/js/Components/ContentUpdateNotification.vue
+++ b/resources/js/Components/ContentUpdateNotification.vue
@@ -1,0 +1,35 @@
+<template>
+    <transition
+        appear
+        enter-active-class="ease-out duration-300"
+        enter-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="ease-in duration-200"
+        leave-class="opacity-100"
+        leave-to-class="opacity-0"
+    >
+        <div class="sticky" style="top: 100px;">
+            <div class="-mt-6 absolute w-full flex justify-center">
+                <button type="button" class="flex items-center justify-center" @click="$emit('reload')">
+                    <div class="px-4 py-2 border dark:border-gray-600 text-center bg-white dark:bg-gray-700 rounded-lg text-gray-800 dark:text-gray-200 font-medium shadow-lg">
+                        <Icon name="medium/refresh" class="w-5 h-5 text-pink-600" :class="[ reloading ? 'animate-spin' : 'animate-pulse-fast group-hover:animate-none' ] "/>
+                        <span class="ml-2"><slot>Content updated</slot></span>
+                        <span class="ml-3 text-pink-600 font-semibold">Reload</span>
+                    </div>
+                </button>
+            </div>
+        </div>
+    </transition>
+</template>
+
+<script>
+import Icon from '@/Components/Icon'
+
+export default {
+    components: {
+        Icon,
+    },
+
+    props: ['reloading'],
+}
+</script>

--- a/resources/js/Pages/Collection.vue
+++ b/resources/js/Pages/Collection.vue
@@ -370,7 +370,7 @@ export default {
         async clearDone() {
             this.processing = true
             await this.$inertia.delete(
-                route('c.destroy-done', this.collection.hashid),
+                route('c.bullets.done.destroy', this.collection.hashid),
                 { preserveScroll: true }
             )
             this.processing = false

--- a/resources/js/Pages/DailyLog.vue
+++ b/resources/js/Pages/DailyLog.vue
@@ -1,5 +1,9 @@
 <template>
     <journal-layout :key="hash">
+        <ContentUpdateNotification v-if="contentUpdateAvailable" :reloading="reloading" @reload="reload">
+            Daily log updated
+        </ContentUpdateNotification>
+
         <div v-if="days.length === 0" class="mb-10 leading-relaxed text-gray-600 dark:text-gray-300">
             <h1 class="text-xl font-semibold text-gray-700 dark:text-gray-300">
                 <Icon name="medium/calendar" auto-size class="mr-1 text-gray-600 dark:text-gray-400" />
@@ -56,25 +60,6 @@
             <new-bullet v-if="i == 0" @input="storeBullet" />
         </div>
 
-        <transition
-            enter-active-class="transition ease-out duration-200"
-            enter-class="transform opacity-0 scale-95"
-            enter-to-class="transform opacity-100 scale-100"
-            leave-active-class="transition ease-in duration-75"
-            leave-class="transform opacity-100 scale-100"
-            leave-to-class="transform opacity-0 scale-95"
-        >
-            <div v-if="contentUpdateAvailable" class="fixed bottom-0 left-0 right-0 mb-4 flex justify-center pointer-events-none">
-                <button
-                    type="button"
-                    class="px-4 py-2 bg-gray-900 bg-opacity-70 text-gray-200 text-base rounded-full pointer-events-auto hover:bg-opacity-100 hover:text-white"
-                    @click="reload"
-                >
-                    <Icon name="small/refresh" auto-size :class="{ 'animate-spin': reloading }" /> Reload
-                </button>
-            </div>
-        </transition>
-
         <subscription-prompt-modal :show="showingSubscriptionPrompt" @close="showingSubscriptionPrompt = false" />
     </journal-layout>
 </template>
@@ -82,6 +67,7 @@
 <script>
     import JournalLayout from '@/Layouts/JournalLayout'
     import Bullet from '@/Components/Bullet'
+    import ContentUpdateNotification from '@/Components/ContentUpdateNotification'
     import NewBullet from '@/Components/NewBullet'
     import SubscriptionPromptModal from '@/Components/SubscriptionPromptModal'
     import Icon from '@/Components/Icon'
@@ -89,6 +75,7 @@
     export default {
         components: {
             Bullet,
+            ContentUpdateNotification,
             JournalLayout,
             NewBullet,
             SubscriptionPromptModal,
@@ -176,8 +163,6 @@
             },
 
             pollForContentUpdates() {
-                console.log('Polling for content updates')
-
                 const contentUpdateCheckInterval = setInterval(async () => {
                     const response = await axios.get(route('daily-log.index', { hashonly: true }))
                     this.contentUpdateAvailable = response.data !== this.hash

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\CollectionController;
 use App\Http\Controllers\CollectionUserController;
 use App\Http\Controllers\DailyLogController;
 use App\Http\Controllers\UserPreferenceController;
-use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -50,25 +49,32 @@ Route::get('/email/verify/{id}/{hash}', function (EmailVerificationRequest $requ
 Route::middleware(['auth:sanctum', 'verified'])->group(function () {
     Route::patch('user/preferences', [UserPreferenceController::class, 'update'])->name('user-preferences.update');
 
-    Route::put('daily-log', [DailyLogController::class, 'move'])->name('daily-log.move');
+    // Daily Log
+
+    Route::put('daily-log', [DailyLogController::class, 'move'])
+        ->name('daily-log.move');
 
     Route::resource('daily-log', DailyLogController::class)
-        ->only('index', 'store', 'update', 'destroy')
-        ->parameters(['daily-log' => 'bullet']);
+        ->parameters(['daily-log' => 'bullet'])
+        ->only('index', 'store', 'update', 'destroy');
+
+    // Collections
 
     Route::resource('c', CollectionController::class)
-        ->only('show', 'store', 'update', 'destroy')
-        ->parameters(['c' => 'collection']);
+        ->parameters(['c' => 'collection'])
+        ->only('show', 'store', 'update', 'destroy');
 
-    Route::delete('c/{collection}/bullets/done', [CollectionBulletDoneController::class, 'destroy'])->name('c.destroy-done');
+    Route::delete('c/{collection}/bullets/done', [CollectionBulletDoneController::class, 'destroy'])
+        ->name('c.bullets.done.destroy');
 
-    Route::put('c/{collection}/bullets', [CollectionBulletController::class, 'move'])->name('c.bullets.move');
+    Route::put('c/{collection}/bullets', [CollectionBulletController::class, 'move'])
+        ->name('c.bullets.move');
 
     Route::resource('c.bullets', CollectionBulletController::class)
-        ->only('store', 'update', 'destroy')
-        ->parameters(['c' => 'collection']);
+        ->parameters(['c' => 'collection'])
+        ->only('store', 'update', 'destroy');
 
     Route::resource('c.users', CollectionUserController::class)
-        ->only('store', 'destroy')
-        ->parameters(['c' => 'collection']);
+        ->parameters(['c' => 'collection'])
+        ->only('store', 'destroy');
 });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,9 @@ module.exports = {
 
     theme: {
         extend: {
+            animation: {
+                'pulse-fast': 'pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+            },
             fontFamily: {
                 sans: ['Inter var', ...defaultTheme.fontFamily.sans],
             },
@@ -56,6 +59,7 @@ module.exports = {
             opacity: ['disabled'],
             typography: ['dark'],
             display: ['dark'],
+            animation: ['group-hover'],
         },
     },
 


### PR DESCRIPTION
When sharing a collection with other people, or when using rocketlog on multiple devices, there are times where the daily log or a collection you are viewing could be updated externally.

This PR adds polling that checks for updates and displays a notification with a reload button. To address performance issues, I have also added caching for bullets.

I didn't want to automatically reload because this might move the content around on the user, however I might look into doing this when the user is idle.

**Desktop**

![image](https://user-images.githubusercontent.com/4977161/129497437-073005b1-30f6-4c44-ba0b-d990800239c6.png)

**Mobile**

![image](https://user-images.githubusercontent.com/4977161/129497448-f8f5fdcb-f4b2-4e68-ba09-7e5f0e63604a.png)
