### PR TITLE
Fix falsey value

### DIFF
--- a/resources/js/Components/NewBullet.vue
+++ b/resources/js/Components/NewBullet.vue
@@ -25,13 +25,13 @@
                 @keydown.up="up"
                 @keydown.down="down"
                 @keydown.enter="
-                    if (! $event.shiftKey && $event.target.value.length) {
+                    if (! $event.shiftKey && $event.target.value.trim() !== '') {
                         $event.preventDefault()
                         create()
                     }
                 "
                 @blur="
-                    if ($event.target.value.length) {
+                    if ($event.target.value.trim() !== '') {
                         create()
                     }
                 "


### PR DESCRIPTION
This PR will fix the 500 error that occurs when you try to submit a new bullet without a value. The previous .length check proved to be falsey as it failed to take whitespace into account. The issue isn't really that not noticable on desktop, but on mobile devices it happens frequently. The issue occurs both on the daily log and the collection log, with the former giving only the Inertia blank white screen and the latter giving a 500 error. I wrote a Dusk test for regression (not included), but it is pretty useless since SSR is not setup therefore I'm not able to perform any assertions on the DOM. I think a simple manual test is sufficent to get this hotfix rolled out.

![Bug](https://user-images.githubusercontent.com/20573863/164800336-c839f844-662c-494d-b23d-08a797fa56f6.gif)
