### PR TITLE
Prevent duplicate submission

### DIFF
--- a/resources/js/Components/NewBullet.vue
+++ b/resources/js/Components/NewBullet.vue
@@ -24,17 +24,8 @@
                 placeholder="Unburden your mind..."
                 @keydown.up="up"
                 @keydown.down="down"
-                @keydown.enter="
-                    if (! $event.shiftKey && $event.target.value.trim() !== '') {
-                        $event.preventDefault()
-                        create()
-                    }
-                "
-                @blur="
-                    if ($event.target.value.trim() !== '') {
-                        create()
-                    }
-                "
+                @keydown.enter.prevent="create"
+                @blur="create"
             ></textarea>
         </div>
     </form>
@@ -61,7 +52,11 @@ export default {
     },
 
     methods: {
-        async create() {
+        async create(event) {
+            if (event.target.value.trim() === '' || this.creating) {
+                return
+            }
+
             this.creating = true;
 
             await this.$listeners.input({ name: this.name })

--- a/resources/js/Components/NewBullet.vue
+++ b/resources/js/Components/NewBullet.vue
@@ -25,13 +25,13 @@
                 @keydown.up="up"
                 @keydown.down="down"
                 @keydown.enter="
-                    if (! $event.shiftKey && $event.target.value.length) {
+                    if (! $event.shiftKey && $event.target.value.trim() !== '') {
                         $event.preventDefault()
                         create()
                     }
                 "
                 @blur="
-                    if ($event.target.value.length) {
+                    if ($event.target.value.trim() !== '') {
                         create()
                     }
                 "

--- a/resources/js/Components/NewBullet.vue
+++ b/resources/js/Components/NewBullet.vue
@@ -24,7 +24,7 @@
                 placeholder="Unburden your mind..."
                 @keydown.up="up"
                 @keydown.down="down"
-                @keydown.enter.prevent="create"
+                @keydown.enter.exact.prevent="create"
                 @blur="create"
             ></textarea>
         </div>


### PR DESCRIPTION
This PR attempts to fix an issue with duplicate submission that occurs only on mobile devices. I've tested thoroughly and I just can't reproduce this at all on desktop. I've cleaned up the keydown a bit and added an additional check. The shift key check has been removed as it is no longer needed since we now make use of the trim method. Let's hope this fixes it. 🤞